### PR TITLE
feat(#2): 컬렉션 생성 시 필요한 Spot 생성 비즈니스 로직 생성

### DIFF
--- a/src/main/java/org/bf/spotservice/collection/domain/Collection.java
+++ b/src/main/java/org/bf/spotservice/collection/domain/Collection.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.bf.spotservice.collection.domain.dto.CollectionDto;
 import org.bf.spotservice.collection.domain.dto.SpotDto;
+import org.bf.spotservice.collection.domain.dto.SpotIdDto;
 import org.bf.spotservice.collection.infrastructure.persistence.converter.SpotConverter;
 
 import java.util.List;
@@ -34,7 +35,7 @@ public class Collection {
     public CollectionDto toDto() {
         return new CollectionDto(
                 this.id,
-                this.spotIds.stream().map(SpotDto::new).toList()
+                this.spotIds.stream().map(SpotIdDto::new).toList()
         );
     }
 


### PR DESCRIPTION
## 🔘Part
- Spot 관련 클래스 변경

## 🔎 작업 내용
- 같은 장소는 여러 유저가 컬렉션에 저장할 수 있기에 latitude, longitude 기반으로 db 조회 후 있으면 가져오고 없으면 추가한다.

## 🔧 점검 내용

## ➕ 이슈 링크

- [#2](https://github.com/Barrier-Free-Friends/spot-service/issues/2)