### PR TITLE
feat(#4): fork 로직 구현

### DIFF
--- a/src/main/java/org/bf/spotservice/collection/application/command/CollectionCommandService.java
+++ b/src/main/java/org/bf/spotservice/collection/application/command/CollectionCommandService.java
@@ -4,6 +4,8 @@ import org.bf.spotservice.collection.application.command.dto.CreateDto;
 import org.bf.spotservice.collection.application.command.dto.UpdateDto;
 import org.bf.spotservice.collection.domain.dto.CollectionIdDto;
 
+import java.util.UUID;
+
 public interface CollectionCommandService {
 
     // 컬렉션 공개 여부 및 이름 변경
@@ -20,5 +22,8 @@ public interface CollectionCommandService {
 
     // 컬렉션에서 장소 삭제
     CollectionIdDto removeSpotIdFromCollection(Long collectionId, Long spotId);
+
+    // 컬렉션 포크 - 기존 컬렉션에, 현재 사용자 id를 파라미터로 받는다
+    CollectionIdDto forkCollection(Long originalCollectionId, UUID userId);
 
 }

--- a/src/main/java/org/bf/spotservice/collection/application/command/CollectionCommandServiceImpl.java
+++ b/src/main/java/org/bf/spotservice/collection/application/command/CollectionCommandServiceImpl.java
@@ -14,6 +14,8 @@ import org.bf.spotservice.spot.domain.SpotRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -72,5 +74,23 @@ public class CollectionCommandServiceImpl implements CollectionCommandService {
 
         return collection.toDto();
 
+    }
+
+    @Override
+    public CollectionIdDto forkCollection(Long originalCollectionId, UUID userId) {
+
+        Collection originalCollection = collectionRepository.findByCollectionId(originalCollectionId).orElseThrow(() -> new CustomException(CollectionErrorCode.COLLECTION_NOT_FOUND));
+
+        if (Boolean.FALSE.equals(originalCollection.getOpen())) {
+          throw new CustomException(CollectionErrorCode.COLLECTION_NOT_PUBLIC);
+        }
+
+        originalCollection.incrementFork();
+
+        Collection newCollection = Collection.createForkedCollection(originalCollection, userId);
+
+        Collection savedForkedCollection = collectionRepository.save(newCollection);
+
+        return savedForkedCollection.toDto();
     }
 }

--- a/src/main/java/org/bf/spotservice/collection/application/error/CollectionErrorCode.java
+++ b/src/main/java/org/bf/spotservice/collection/application/error/CollectionErrorCode.java
@@ -11,6 +11,7 @@ public enum CollectionErrorCode implements BaseErrorCode {
 
     COLLECTION_EMPTY(HttpStatus.NO_CONTENT, "204", "등록된 컬렉션이 없습니다."),
     COLLECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "컬렉션을 찾을 수 없습니다."),
+    COLLECTION_NOT_PUBLIC(HttpStatus.FORBIDDEN, "403", "비공개 컬렉션입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/bf/spotservice/collection/domain/Collection.java
+++ b/src/main/java/org/bf/spotservice/collection/domain/Collection.java
@@ -39,7 +39,7 @@ public class Collection extends Auditable {
     @Column(name = "collection_name")
     private String name;
 
-    private int fork;
+    private int fork = 0;
 
     public Collection(UUID userId, Boolean open, String name) {
         this.userId = userId;
@@ -83,5 +83,21 @@ public class Collection extends Auditable {
             throw new CustomException(SpotErrorCode.SPOT_NOT_FOUND);
         }
         this.spotIds.remove(spotId);
+    }
+
+    public void incrementFork() {
+        this.fork += 1;
+    }
+
+    public static Collection createForkedCollection(Collection originalCollection, UUID newUserId) {
+        Collection forkedCollection = new Collection(newUserId, true, "Forked: " + originalCollection.getName());
+
+        List<Long> originalSpotIds = originalCollection.getSpotIds() == null ? new ArrayList<>() : originalCollection.getSpotIds();
+
+        for (Long spotId : originalSpotIds) {
+            forkedCollection.addSpotId(spotId);
+        }
+
+        return forkedCollection;
     }
 }

--- a/src/main/java/org/bf/spotservice/collection/domain/CollectionRepository.java
+++ b/src/main/java/org/bf/spotservice/collection/domain/CollectionRepository.java
@@ -1,7 +1,13 @@
 package org.bf.spotservice.collection.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface CollectionRepository extends JpaRepository<Collection, Long> {
 
+    @Query("select c from Collection c where c.id = :collectionId")
+    Optional<Collection> findByCollectionId(@Param("collectionId") Long collectionId);
 }


### PR DESCRIPTION
- 제목 : feat(issue 번호): 기능명
  ex) feat(17): pull request template 작성
  (확인 후 지워주세요)

## 🔘Part
- CommandService에서 fork 관련 로직 추가

## 🔎 작업 내용

- 컬렉션 리스트가 있고, 이를 다른 사람이 fork 할 수 있다.
- 사용자id와, fork하고자 하는 collectionId를 이용한다

- 원본 CollectionId가 db에 존재하는 지 확인해야한다.
- 그 Colleciton의 open이 true인지 확인한다.
- 특정 컬렉션에 fork를 하게 되면 forkCount 증가

## ➕ 이슈 링크

- [#4 ](https://github.com/Barrier-Free-Friends/spot-service/issues/4)