### PR TITLE
refactor(#16): 유저 id가 필요한 로직 재구성

### DIFF
--- a/src/main/java/org/bf/spotservice/collection/application/command/CollectionCommandServiceImpl.java
+++ b/src/main/java/org/bf/spotservice/collection/application/command/CollectionCommandServiceImpl.java
@@ -50,6 +50,8 @@ public class CollectionCommandServiceImpl implements CollectionCommandService {
     @Override
     public void deleteCollection(Long collectionId) {
 
+        securityUtils.getCurrentUserId();
+
         Collection collection = collectionRepository.findById(collectionId).orElseThrow(() -> new CustomException(CollectionErrorCode.COLLECTION_NOT_FOUND));
 
         String username = securityUtils.getCurrentUsername();

--- a/src/main/java/org/bf/spotservice/collection/application/error/CollectionErrorCode.java
+++ b/src/main/java/org/bf/spotservice/collection/application/error/CollectionErrorCode.java
@@ -11,7 +11,8 @@ public enum CollectionErrorCode implements BaseErrorCode {
 
     COLLECTION_EMPTY(HttpStatus.NO_CONTENT, "204", "등록된 컬렉션이 없습니다."),
     COLLECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "컬렉션을 찾을 수 없습니다."),
-    COLLECTION_NOT_PUBLIC(HttpStatus.FORBIDDEN, "403", "비공개 컬렉션입니다.")
+    COLLECTION_NOT_PUBLIC(HttpStatus.FORBIDDEN, "403", "비공개 컬렉션입니다."),
+    COLLECTION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "403", "허용되지 않은 컬렉션 접근입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/bf/spotservice/collection/application/query/CollectionQueryService.java
+++ b/src/main/java/org/bf/spotservice/collection/application/query/CollectionQueryService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface CollectionQueryService {
 
@@ -14,7 +15,7 @@ public interface CollectionQueryService {
     List<CollectionIdDto> getCollections();
 
     // 특정 컬렉션 조회
-    CollectionDto getCollection(Long id);
+    CollectionDto getCollection(Long id, UUID userId);
 
     // 컬렉션 랭킹 조회
     Page<CollectionRankDto> getCollectionsByFork(Pageable pageable);

--- a/src/main/java/org/bf/spotservice/collection/domain/CollectionDetailRepository.java
+++ b/src/main/java/org/bf/spotservice/collection/domain/CollectionDetailRepository.java
@@ -1,15 +1,15 @@
 package org.bf.spotservice.collection.domain;
 
 import org.bf.spotservice.collection.application.dto.CollectionRankDto;
-import org.bf.spotservice.collection.domain.dto.CollectionDto;
 import org.bf.spotservice.collection.domain.dto.CollectionIdDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface CollectionDetailRepository {
-    List<CollectionIdDto> findAll();
+    List<CollectionIdDto> findAll(UUID currentUserId);
 
     Page<CollectionRankDto> findCollectionByForkDesc(Pageable pageable);
 

--- a/src/main/java/org/bf/spotservice/collection/infrastructure/persistence/CollectionDetailsDao.java
+++ b/src/main/java/org/bf/spotservice/collection/infrastructure/persistence/CollectionDetailsDao.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 
@@ -32,12 +33,15 @@ public class CollectionDetailsDao implements CollectionDetailRepository {
     private final CollectionRepository collectionRepository;
     private final SpotRepository spotRepository;
     @Override
-    public List<CollectionIdDto> findAll() {
+    public List<CollectionIdDto> findAll(UUID userId) {
 
         QCollection collection = QCollection.collection;
         QSpot spot = QSpot.spot;
 
-        List<Collection> collections = queryFactory.selectFrom(collection).fetch();
+        List<Collection> collections = queryFactory
+                .selectFrom(collection)
+                .where(collection.userId.eq(userId))
+                .fetch();
 
         if (collections.isEmpty()) {
             return List.of();

--- a/src/main/java/org/bf/spotservice/collection/infrastructure/persistence/converter/SpotConverter.java
+++ b/src/main/java/org/bf/spotservice/collection/infrastructure/persistence/converter/SpotConverter.java
@@ -1,6 +1,7 @@
 package org.bf.spotservice.collection.infrastructure.persistence.converter;
 
 import jakarta.persistence.AttributeConverter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
@@ -8,6 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Slf4j
 public class SpotConverter implements AttributeConverter<List<Long>, String> {
     @Override
     public String convertToDatabaseColumn(List<Long> longs) {
@@ -17,11 +19,18 @@ public class SpotConverter implements AttributeConverter<List<Long>, String> {
     @Override
     public List<Long> convertToEntityAttribute(String s) {
 
-        if (s == null || s.isEmpty()) {
-            return new ArrayList<>();
+        try {
+            if (s == null || s.isEmpty()) {
+                return new ArrayList<>();
+            }
+            return StringUtils.hasText(s) ?
+                    Stream.of(s.split(",")).map(Long::valueOf).collect(Collectors.toList())
+                    : List.of();
+        } catch (Exception e) {
+            log.error("컨버터 변환 실패! 문제 데이터: {}", s);
+            throw e;
         }
-        return StringUtils.hasText(s) ?
-                Stream.of(s.split(",")).map(Long::valueOf).collect(Collectors.toList())
-                : List.of();
+
+
     }
 }

--- a/src/main/java/org/bf/spotservice/collection/presentation/CollectionController.java
+++ b/src/main/java/org/bf/spotservice/collection/presentation/CollectionController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.bf.global.infrastructure.CustomResponse;
 import org.bf.global.infrastructure.success.GeneralSuccessCode;
+import org.bf.global.security.SecurityUtils;
 import org.bf.spotservice.collection.application.command.CollectionCommandService;
 import org.bf.spotservice.collection.application.command.dto.CreateDto;
 import org.bf.spotservice.collection.application.command.dto.UpdateDto;
@@ -56,8 +57,6 @@ public class CollectionController {
     }
 
     @GetMapping("/collection/all")
-//    @GetMapping("/collection/{userId}/all")
-    // 유저 연결 후 수정해야함
     @Operation(description = "컬렉션 조회 - 사용자가 갖고 있는 컬렉션을 조회하고 각 컬렉션에는 spot id 목록만 반환합니다.")
     public CustomResponse<?> getCollection() {
 
@@ -67,9 +66,9 @@ public class CollectionController {
 
     @GetMapping("/collection/{collectionId}")
     @Operation(description = "컬렉션 상세 조회 - 특정 컬렉션의 상세 정보를 조회합니다.")
-    public CustomResponse<?> getCollection(@PathVariable("collectionId") Long collectionId) {
+    public CustomResponse<?> getCollection(@PathVariable("collectionId") Long collectionId, SecurityUtils securityUtils) {
 
-        CollectionDto collectionDto = collectionQueryService.getCollection(collectionId);
+        CollectionDto collectionDto = collectionQueryService.getCollection(collectionId, securityUtils.getCurrentUserId());
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, collectionDto);
     }
 

--- a/src/main/java/org/bf/spotservice/global/infrastructure/persistence/config/SpotSwaggerConfig.java
+++ b/src/main/java/org/bf/spotservice/global/infrastructure/persistence/config/SpotSwaggerConfig.java
@@ -1,0 +1,58 @@
+package org.bf.spotservice.global.infrastructure.persistence.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+public class SpotSwaggerConfig {
+
+
+    private final String PREFIX = "/v1/point";
+
+    @Bean
+    public OpenAPI openAPI(@Value("${openapi.service.url}") String url) {
+        return new OpenAPI()
+                .servers(List.of(new Server().url(url)))
+                .components(new Components().addSecuritySchemes("Bearer", new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("Bearer"))
+                .info(new Info().title("Barrier-Free-Friends Point Service").version("1.0")
+                        .description("POINT API"));
+    }
+
+    @Bean
+    public OpenApiCustomizer addPrefixToPaths() {
+        return openApi -> {
+            Paths paths = openApi.getPaths();
+            if (paths == null) return;
+
+            // 기존 paths에 prefix 붙여서 추가
+            Map<String, PathItem> original = new LinkedHashMap<>(paths);
+            for (String path : original.keySet().toArray(new String[0])) {
+                String prefixed = PREFIX + path;
+                if (!paths.containsKey(prefixed)) {
+                    PathItem item = original.get(path);
+                    paths.addPathItem(prefixed, item);
+                }
+            }
+
+            // 실제 엔드포인트는 제거하고 게이트웨이를 통한 엔드포인트만 노출
+            original.keySet().forEach(s -> {
+                if (!s.startsWith(PREFIX)) paths.remove(s);
+            });
+        };
+    }
+}


### PR DESCRIPTION
- 제목 : refactor(#16): 유저 id가 필요한 로직 재구성

## 🔘Part
- 본인 컬렉션만 조회할 수 있도록 수정

## 🔎 작업 내용

- SecurityUtils를 이용해 userId를 가져오고 조회


## 🔧 점검 내용

## ➕ 이슈 링크

- [#16](https://github.com/Barrier-Free-Friends/spot-service/issues/16)