### PR TITLE
refactor(#23): 컬렉션 fork 시 낙관적 락 사용

### DIFF
--- a/src/main/java/org/bf/spotservice/collection/application/command/CollectionCommandServiceImpl.java
+++ b/src/main/java/org/bf/spotservice/collection/application/command/CollectionCommandServiceImpl.java
@@ -9,6 +9,7 @@ import org.bf.spotservice.collection.application.error.CollectionErrorCode;
 import org.bf.spotservice.collection.domain.Collection;
 import org.bf.spotservice.collection.domain.CollectionRepository;
 import org.bf.spotservice.collection.domain.dto.CollectionIdDto;
+import org.bf.spotservice.collection.support.RetryOnOptimisticLock;
 import org.bf.spotservice.spot.application.error.SpotErrorCode;
 import org.bf.spotservice.spot.domain.SpotRepository;
 import org.springframework.stereotype.Service;
@@ -81,6 +82,7 @@ public class CollectionCommandServiceImpl implements CollectionCommandService {
     }
 
     @Override
+    @RetryOnOptimisticLock
     public CollectionIdDto forkCollection(Long originalCollectionId, UUID userId) {
 
         Collection originalCollection = collectionRepository.findByCollectionId(originalCollectionId).orElseThrow(() -> new CustomException(CollectionErrorCode.COLLECTION_NOT_FOUND));

--- a/src/main/java/org/bf/spotservice/collection/domain/Collection.java
+++ b/src/main/java/org/bf/spotservice/collection/domain/Collection.java
@@ -41,6 +41,9 @@ public class Collection extends Auditable {
 
     private int fork = 0;
 
+    @Version
+    private Long version = 0L;
+
     public Collection(UUID userId, Boolean open, String name) {
         this.userId = userId;
         this.open = open;

--- a/src/main/java/org/bf/spotservice/collection/support/OptimisticLockRetryAspect.java
+++ b/src/main/java/org/bf/spotservice/collection/support/OptimisticLockRetryAspect.java
@@ -1,0 +1,130 @@
+package org.bf.spotservice.collection.support;
+
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 낙관적 락 예외 발생 시 지정된 횟수만큼 재시도하는
+ */
+
+@Aspect
+@Component
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE) // 재시도 Aspect가 트랜잭션 Aspect보다 먼저 실행되도록 설정
+@RequiredArgsConstructor
+public class OptimisticLockRetryAspect {
+
+    private final OptimisticLockRetryProperties props;
+
+    private static final List<Class<?>> RETRYABLE_EXCEPTIONS_TYPES;
+
+    static {
+        List<Class<?>> types = new ArrayList<>();
+
+        // 직접 참조 가능한 JPA 예외 추가
+        types.add(OptimisticLockException.class);
+
+        String[] names = {
+                "org.springframework.orm.ObjectOptimisticLockingFailureException",
+                "org.springframework.dao.OptimisticLockingFailureException",
+                "org.hibernate.StaleObjectStateException"
+        };
+
+        for (String name : names) {
+            try {
+                types.add(Class.forName(name));
+            } catch (ClassNotFoundException ignored) {
+            }
+        }
+        RETRYABLE_EXCEPTIONS_TYPES = Collections.unmodifiableList(types);
+    }
+
+    @Around("@annotation(org.bf.spotservice.collection.support.RetryOnOptimisticLock)")
+    public Object aroundRetry(final ProceedingJoinPoint joinPoint) throws Throwable {
+
+        int maxAttempts = props.getMaxAttempts();
+        long delay = props.getInitialDelayMs();
+        double multiplier = props.getMultiplier();
+        long maxDelay = props.getMaxDelayMs();
+
+        int attempt = 0;
+        Throwable lastThrowable = null;
+
+        // 재시도 루프 -> 낙관적 락 예외 발생 시 재시도\
+        /**
+         * attempt는 0부터 시작하여 최대 시도 횟수까지 증가.
+         * 성공 시 결과 반환. 재시도 중 성공하면 로그 출력
+         */
+        while (attempt < maxAttempts) {
+            attempt++;
+            try {
+                if (attempt > 1) {
+                    log.debug("재시도 {}/{}  {}", attempt, maxAttempts, joinPoint.getSignature());
+                }
+                Object result = joinPoint.proceed();
+                if (attempt > 1) {
+                    log.info("재시도 성공 {}/{}  {}", attempt, maxAttempts, joinPoint.getSignature());
+                }
+                return result;
+            } catch (Throwable ex) {
+                lastThrowable = ex;
+                // 재시도 가능한 예외인지 확인
+                if (isRetryable(ex)) {
+                    log.warn("낙관적 락 재시도 {}/{}  {}: {}", attempt, maxAttempts, joinPoint.getSignature(), ex.getMessage());
+                    if (attempt >= maxAttempts) {
+                        log.error("재시도 횟수 초과 ({})  {}", maxAttempts, joinPoint.getSignature());
+                        throw ex;
+                    }
+                    // 백오프 설정
+                    try {
+                        Thread.sleep(delay);
+                    } catch (InterruptedException ie) {
+                        // 현재 스레드 인터럽트 상태 복원하고 예외 재던짐
+                        Thread.currentThread().interrupt();
+                        throw ie;
+                    }
+                    delay = Math.min((long) (delay * multiplier), maxDelay);
+                    continue;
+                }
+                throw ex;
+            }
+        }
+
+        // 루프 나왔는데도 성공 못한 경우 마지막 예외 던짐
+        if (lastThrowable != null) {
+            throw lastThrowable;
+        }
+        return null;
+    }
+
+    private boolean isRetryable(Throwable ex) {
+
+        if (ex == null) return false;
+
+        // Error는 재시도 대상에서 제외 -> 확인 필요
+        if (ex instanceof Error) return false;
+
+        // 예외 및 원인 체인 검사
+        Throwable t = ex;
+        while (t != null) {
+            for (Class<?> cls : RETRYABLE_EXCEPTIONS_TYPES) {
+                if (cls.isInstance(t)) return true;
+            }
+
+            t = t.getCause();
+        }
+        return false;
+    }
+}
+

--- a/src/main/java/org/bf/spotservice/collection/support/OptimisticLockRetryProperties.java
+++ b/src/main/java/org/bf/spotservice/collection/support/OptimisticLockRetryProperties.java
@@ -1,0 +1,19 @@
+package org.bf.spotservice.collection.support;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "spotservice.optimistic-lock.retry")
+@Getter
+@Setter
+public class OptimisticLockRetryProperties {
+
+    private int maxAttempts = 3;
+    private long initialDelayMs = 100;
+    private double multiplier = 2.0;
+    private long maxDelayMs = 1000;
+}
+

--- a/src/main/java/org/bf/spotservice/collection/support/RetryOnOptimisticLock.java
+++ b/src/main/java/org/bf/spotservice/collection/support/RetryOnOptimisticLock.java
@@ -1,0 +1,13 @@
+package org.bf.spotservice.collection.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// retry 어노테이션 구성. 낙관적 락 예외 발생 시 재시도할 메서드에 추가
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RetryOnOptimisticLock {
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,12 @@ eureka:
 
 server:
   port: 3500
+
+# 낙관적 락 재사용 설정
+spotservice:
+  optimistic-lock:
+    retry:
+      maxAttempts: 3
+      initialDelayMs: 100
+      multiplier: 2.0
+      maxDelayMs: 1000


### PR DESCRIPTION
- 제목 : refactor(#23 ): 컬렉션 fork 시 낙관적 락 사용

## 🔘Part

- CollectionCommandServiceImpl


## 🔎 작업 내용
- Retry 어노테이션 생성 (version 기준으로 충돌 시 재시도하는 로직)
- AOP를 활용해 비즈니스 로직과 재시도 로직을 분리
- 재시도 Aspect가 트랜잭션 Aspect보다 더 바깥쪽에서 감싸도록 구성


## 🔧 점검 내용

- 관리자가 유의해서 확인해야할 내용이
- 있다면 적어주세요

## ➕ 이슈 링크

- [#23](https://github.com/Barrier-Free-Friends/spot-service/issues/23)